### PR TITLE
Added new Feature- Displays a quote on startup (only for linux)

### DIFF
--- a/motivate/Launch_screen_disp.py
+++ b/motivate/Launch_screen_disp.py
@@ -1,0 +1,39 @@
+import Tkinter as Tk
+import os,sys, subprocess
+from threading import Timer
+
+def exit_fun ():
+	os._exit(0)
+text_col = "white"
+bg_col = "#090e11"
+root = Tk.Tk()
+root.title("Enter pattern")
+
+root.attributes("-alpha",0)
+root.configure(background=bg_col)
+w,h= 500,300
+ws = root.winfo_screenwidth()
+hs = root.winfo_screenheight()
+x = (ws/2) - (w/2)
+y = (hs/2) - (h/2)
+root.geometry('%dx%d+%d+%d' % (w, h, x, y))
+p = os.popen("motivate")
+text_me =str(p.read())
+text_me = text_me.lstrip("\033[1;36m" + "\"")
+quote = text_me[:text_me.find( "\"" + "\033[1;m" + "\n\t\t"+ "\033[1;35m" + "--")]
+text_me = text_me.lstrip(quote +  "\"" + "\033[1;m" + "\n\t\t"+ "\033[1;35m" + "--")
+author = text_me[:text_me.find("\033[1;m")]
+
+Timer(6.0, exit_fun).start()
+#quote = quote.replace(".",".\n")
+
+
+Tk.Label(root, pady=10, text="Quote for the day!",fg="#64d671",bg=bg_col,wraplength = w-30,font = "Helvetica 15 bold italic").pack()
+Quote_l = Tk.Label(root,text="\"" + quote + "\"",pady = h/6,fg=text_col,bg=bg_col,wraplength = w-30,font = "Arial 12 bold italic")
+Author_l = Tk.Label(root,text=" - " +author,fg="#ff8484",bg=bg_col, font= "times_new_roman 11 italic")
+Quote_l.pack()
+Author_l.pack()
+b1 = Tk.Button(root,text="   ", justify =Tk.LEFT,command = "exit")
+b1.config(activebackground = "#cc8251")
+b1.pack(pady = 10)
+root.mainloop()

--- a/motivate/install.sh
+++ b/motivate/install.sh
@@ -15,3 +15,12 @@ ln -sf $PWD/data/ $INSTALLDIR/motivate/data
 
 # Copy the executable
 cp motivate.py /usr/local/bin/motivate
+
+echo "Do you want to get quotes during startup ? : "
+
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) cp Launch_screen_disp.py $INSTALLDIR/motivate/Launch_screen_disp.py; sed -i "s:python $INSTALLDIR/motivate/Launch_screen_disp.py::g  " ~/.xprofile ;echo "python $INSTALLDIR/motivate/Launch_screen_disp.py" >> ~/.xprofile;echo "Startup Quotes setup Successfully";break;;
+        No ) exit;;
+    esac
+done


### PR DESCRIPTION
Now during installation you can choose whether you want to display quotes during startup. These quotes stay for 7 seconds then the desktop env. loads. If one wants he/ she can close it and load the desktop before these 7 seconds.

Main motivation was to create a widget. But widget takes up a lot of battery. Also widgets or screenlets in case of ubuntu are not in active dev. and have been left untouched for quite a time now. So I opted to show a quote during startup instead of placing a widget inside.