### PR TITLE
Fix a KeyError bug when reading json files with capitalized key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cache/
 dist/
 motivate.egg-info/
 .DS_Store
+
+moti
+mmoti

--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ If you have no root priviledge, install in this way:
 ```
 $ git clone https://github.com/mubaris/motivate.git
 $ cd motivate
-ln -s $PWD/motivate/motivate.py moti
-ln -s $PWD/dummy.sh mmoti
-export PATH=$PWD:$PATH
+$ ln -s $PWD/motivate/motivate.py moti
+$ ln -s $PWD/dummy.sh mmoti
+
+$ export PATH=$PWD:$PATH
+$ # echo 'export PATH=$PWD:$PATH' >> ~/.bashrc
+
 ```
 Later you can run by calling `moti` (a single run) or `mmoti` (keep running until you break it).
+After doing so, I found that python 2.x is enough to run this script.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ $ source ~/.bashrc
 
 zsh users should replace `.bashrc` with `.zshrc`.
 
+If you have no root priviledge, install in this way:
+```
+$ git clone https://github.com/mubaris/motivate.git
+$ cd motivate
+ln -s $PWD/motivate/motivate.py moti
+ln -s $PWD/dummy.sh mmoti
+export PATH=$PWD:$PATH
+```
+Later you can run by calling `moti` (a single run) or `mmoti` (keep running until you break it).
+
 ### Windows
 
 * Make sure you have Python3 on your path.

--- a/dummy.sh
+++ b/dummy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+while true
+    do 
+        moti
+        sleep 1m 
+    done

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import os

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import json
 import os

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -37,18 +37,36 @@ def quote():
     with open(filename) as json_data:
         quotes = json.load(json_data)
         ran_no = random.randint(1, len(quotes["data"])) - 1
-        quote = quotes["data"][ran_no]["quote"]
-        author = quotes["data"][ran_no]["author"]
-        if platform.system() == "Windows":
-            quote = "\"" + quote + "\""
-            author = "--" + author
-            white_code = ""
+        if "quote" in quotes["data"][ran_no]:
+            quote = quotes["data"][ran_no]["quote"]
+            author = quotes["data"][ran_no]["author"]
+            if platform.system() == "Windows":
+                quote = "\"" + quote + "\""
+                author = "--" + author
+                white_code = ""
+            else:
+                quote = "\033[1;36m" + "\"" + quote + "\"" + "\033[1;m"
+                author = "\033[1;35m" + "--" + author + "\033[1;m"
+                white_code = "\x1b[0m"
+            output = quote + "\n\t\t" + author
+            print(output + white_code)
         else:
-            quote = "\033[1;36m" + "\"" + quote + "\"" + "\033[1;m"
-            author = "\033[1;35m" + "--" + author + "\033[1;m"
-            white_code = "\x1b[0m"
-        output = quote + "\n\t\t" + author
-        print(output + white_code)
+            print ("---------------Debug info begins:--------------")
+            print("This is a message indicating an error in your json database:")
+            print("No key 'quote' is found in the file: "+filename+", item_index = "+str(ran_no))
+            print("Possibly this json file uses capitalized inital letter in its key.")
+            print("You might need to change substitute 'Quote' to 'quote', and 'Author' to 'author'.")
+            print("Try to print this problematic item:\n"+str(quotes["data"][ran_no]))
+            print ("---------------Debug info ends:--------------")
+            cmd_tmp = 'sed -i "s/\"Author\"/\"author\"/g; s/\"Quote\"/\"quote\"/g" '+filename
+            print("Try to fix the problem by using command:")
+            print(cmd_tmp)
+            os.system(cmd_tmp)
+            print("Let's check the output:")
+            f_tmp = open(filename)
+            quotes = json.load(f_tmp)
+            print(str(quotes["data"][ran_no]))
+            print("Hopfully this problem has been solved.")
 
 
 if __name__ == "__main__":

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -21,8 +21,11 @@ def getlink(file):
 
 
 def quote():
-    abspath = getlink(__file__)
-    data_dir = os.path.join(abspath, 'share', 'motivate', 'data')
+    abspath = getlink(__file__) 
+    if abspath == '/usr/local':
+        data_dir = os.path.join(abspath, 'share', 'motivate', 'data')
+    else:
+        data_dir = os.path.join(abspath, 'motivate', 'data')
     try:
         num_of_json = len([f for f in os.listdir(data_dir)
                            if os.path.isfile(os.path.join(data_dir, f))])


### PR DESCRIPTION
About commit: a1260483a766fa6786d3c676077be782a3045313
In 104.json, someone used key "Author"/"Quote", which will lead to KeyError because the program uses "quote" as the key.
I add a line to detect the key "quote". If key "quote" is not found in an item, several lines of debug information will be printed out. It will also try to automatically fix the problematic json file by using 'sed' substitution.
Another way to solve the problem is to update the json files directly, like Pull #92 .

About other commits: 
I modified the python and readme files so that installation and usage can be done by an user without root priviledge. I also added a script to continuously run the printing. Personally I use this when I am about to leave the computer. I hope to keep a ssh connection alive by keeping printing something serious. 
  
  
  