### PR TITLE
Handle with ValueError in json.load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ $ motivate
 ## Contribution
 The most popular way to contribute is adding [new quotes](https://github.com/mubaris/motivate/issues/3). You do it by adding next JSON file in `motivate/data/` directory. The rule is 20 quotes per file.
 
+Before you submit your new JSON file, it is helpful to validate your file at this [website](https://jsonlint.com/) to make sure it is formatly correct.
+
 But any improvements are welcome - just open a pull request with some description.
 
 You're also welcome to discuss the idea on [Gitter Chat](https://gitter.im/pymotivate/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge).

--- a/motivate/data/104.json
+++ b/motivate/data/104.json
@@ -1,68 +1,84 @@
 {
 	"data": [
-	{
-		"Author": "Stephen C. Hogan", 
-		"Quote": "You can't have a million-dollar dream with a minimum-wage work ethic."}, {"Author": "George Bernard Shaw", "Quote": "When I was young, I observed that nine out of 10 things I did were failures. So I did 10 times more work."}, {"Author": "Henry Rollins", "Quote": "If you have an idea of what you want to do in your future, you must go at it with almost monastic obsession, be it music, the ballet or just a basic degree. You have to go at it single-mindedly and let nothing get in your way."}, {"Author": "William James", "Quote": "Give your dreams all you've got and you'll be amazed at the energy that comes out of you."
+	    {
+            "author": "Stephen C. Hogan", 
+            "quote": "You can't have a million-dollar dream with a minimum-wage work ethic."
+        }, 
+        {
+            "author": "George Bernard Shaw",
+            "quote": "When I was young, I observed that nine out of 10 things I did were failures. So I did 10 times more work."
+        },
+        {
+            "author": "Henry Rollins",
+            "quote": "If you have an idea of what you want to do in your future, you must go at it with almost monastic obsession, be it music, the ballet or just a basic degree. You have to go at it single-mindedly and let nothing get in your way."
+        },
+        {
+            "author": "William James",
+            "quote": "Give your dreams all you've got and you'll be amazed at the energy that comes out of you."
 		}, 
 		{
-			"Author": "Sophia Loren", 
-			"Quote": "Many people think they want things, but they don't really have the strength, the discipline. They are weak. I believe that you get what you want if you want it badly enough."
+			"author": "Sophia Loren", 
+			"quote": "Many people think they want things, but they don't really have the strength, the discipline. They are weak. I believe that you get what you want if you want it badly enough."
 		}, 
 		{
-			"Author": "Swami Sivananda", 
-			"Quote": "Put your heart, mind, intellect and soul even to your smallest acts. This is the secret of success."}, {"Author": "Martin Luther King, Jr.", "Quote": "If a man is called a street sweeper, he should sweep streets even as Michelangelo painted, or Beethoven composed music, or Shakespeare wrote poetry. He should sweep streets so well that all the hosts of heaven and Earth will pause to say, 'Here lived a great street sweeper who did his job well.'"
+			"author": "Swami Sivananda", 
+			"quote": "Put your heart, mind, intellect and soul even to your smallest acts. This is the secret of success."
+        },
+        {
+            "author": "Martin Luther King, Jr.",
+            "quote": "If a man is called a street sweeper, he should sweep streets even as Michelangelo painted, or Beethoven composed music, or Shakespeare wrote poetry. He should sweep streets so well that all the hosts of heaven and Earth will pause to say, 'Here lived a great street sweeper who did his job well.'"
 		}, 
 		{
-			"Author": "Pope Paul VI", 
-			"Quote": "All life demands struggle. Those who have everything given to them become lazy, selfish and insensitive to the real values of life. The very striving and hard work that we so constantly try to avoid is the major building block in the person we are today."
+			"author": "Pope Paul VI", 
+			"quote": "All life demands struggle. Those who have everything given to them become lazy, selfish and insensitive to the real values of life. The very striving and hard work that we so constantly try to avoid is the major building block in the person we are today."
 		}, 
 		{
-			"Author": "Stephen King", 
-			"Quote": "Talent is cheaper than table salt. What separates the talented individual from the successful one is a lot of hard work."
+			"author": "Stephen King", 
+			"quote": "Talent is cheaper than table salt. What separates the talented individual from the successful one is a lot of hard work."
 		}, 
 		{
-			"Author": "J.G. Holland", "Quote": 
+			"author": "J.G. Holland", "quote": 
 			"God gives every bird its food, but He does not throw it into its nest."
 		}, 
 		{
-			"Author": "Edward H. Harriman", 
-			"Quote": "Much good work is lost for the lack of a little more."
+			"author": "Edward H. Harriman", 
+			"quote": "Much good work is lost for the lack of a little more."
 		}, 
 		{
-			"Author": "Marvin Phillips (or an unknown author)", 
-			"Quote": "The difference between try and triumph is a little umph."
+			"author": "Marvin Phillips (or an unknown author)", 
+			"quote": "The difference between try and triumph is a little umph."
 		}, 
 		{
-			"Author": "Garth Henrichs", 
-			"Quote": "The person who is waiting for something to turn up might start with their shirt sleeves."
+			"author": "Garth Henrichs", 
+			"quote": "The person who is waiting for something to turn up might start with their shirt sleeves."
 		}, 
 		{
-			"Author": "Marcus Washling", 
-			"Quote": "Those at the top of the mountain didn't fall there."
+			"author": "Marcus Washling", 
+			"quote": "Those at the top of the mountain didn't fall there."
 		}, 
 		{
-			"Author": "Robert Brault", 
-			"Quote": "If you feel you are down on your luck, check the level of your effort."
+			"author": "Robert Brault", 
+			"quote": "If you feel you are down on your luck, check the level of your effort."
 		}, 
 		{
-			"Author": "Terri Guillemets", 
-			"Quote": "You're either changing your life or you're not. No waiting for this or that or better weather or other hurdles. Hurdles are the change."
+			"author": "Terri Guillemets", 
+			"quote": "You're either changing your life or you're not. No waiting for this or that or better weather or other hurdles. Hurdles are the change."
 		}, 
 		{
-			"Author": "Chinese proverb", 
-			"Quote": "Be not afraid of going slowly. Be afraid only of standing still."
+			"author": "Chinese proverb", 
+			"quote": "Be not afraid of going slowly. Be afraid only of standing still."
 		}, 
 		{
-			"Author": "Dutch proverb", 
-			"Quote": "He who is outside his door has the hardest part of his journey behind him."
+			"author": "Dutch proverb", 
+			"quote": "He who is outside his door has the hardest part of his journey behind him."
 		}, 
 		{
-			"Author": "Margaret Thatcher", 
-			"Quote": "I do not know anyone who has got to the top without hard work. That is the recipe. It will not always get you to the top, but should get you pretty near."
+			"author": "Margaret Thatcher", 
+			"quote": "I do not know anyone who has got to the top without hard work. That is the recipe. It will not always get you to the top, but should get you pretty near."
 		}, 
 		{
-			"Author": "George Bernard Shaw", 
-			"Quote": "The people who get on in this world are the people who get up and look for the circumstances they want, and, if they can\u00e2\u20ac\u2122t find them, make them."
+			"author": "George Bernard Shaw", 
+			"quote": "The people who get on in this world are the people who get up and look for the circumstances they want, and, if they can\u00e2\u20ac\u2122t find them, make them."
 		}
 	]
 }

--- a/motivate/data/105.json
+++ b/motivate/data/105.json
@@ -1,112 +1,112 @@
 {
 	"data": [
 		{
-			"Author": "Arthur C. Clarke", 
-			"Quote": "The only way of discovering the limits of the possible is to venture a little way past them into the impossible."
+			"author": "Arthur C. Clarke", 
+			"quote": "The only way of discovering the limits of the possible is to venture a little way past them into the impossible."
 		},
 		{
-			"Author": "Roy T. Bennett", 
-			"Quote": "It's only after you've stepped outside your comfort zone that you begin to change, grow, and transform."
+			"author": "Roy T. Bennett", 
+			"quote": "It's only after you've stepped outside your comfort zone that you begin to change, grow, and transform."
 		},
 		{
-			"Author": "Roy T. Bennett", 
-			"Quote": "Don't be pushed around by the fears in your mind. Be led by the dreams in your heart."
+			"author": "Roy T. Bennett", 
+			"quote": "Don't be pushed around by the fears in your mind. Be led by the dreams in your heart."
 		},
 		{
-			"Author": "Confucius", 
-			"Quote": "The man who moves a mountain begins by carrying away small stones."
+			"author": "Confucius", 
+			"quote": "The man who moves a mountain begins by carrying away small stones."
 		},
 		{
-			"Author": "Paulo Coelho", 
-			"Quote": "Nothing in the world is ever completely wrong. Even a stopped clock is right twice a day."
+			"author": "Paulo Coelho", 
+			"quote": "Nothing in the world is ever completely wrong. Even a stopped clock is right twice a day."
 		},
 		{
-			"Author": "Napoleon Hill", 
-			"Quote": "When defeat comes, accept it as a signal that your plans are not sound, rebuild those plans, and set sail once more toward your coveted goal."
+			"author": "Napoleon Hill", 
+			"quote": "When defeat comes, accept it as a signal that your plans are not sound, rebuild those plans, and set sail once more toward your coveted goal."
 		},
 		{
-			"Author": "Lily Tomlin", 
-			"Quote": "I said 'Somebody should do something about that.' Then I realized I am somebody."
+			"author": "Lily Tomlin", 
+			"quote": "I said 'Somebody should do something about that.' Then I realized I am somebody."
 		},
 		{
-			"Author": "Christopher McCandless", 
-			"Quote": "The very basic core of a man's living spirit is his passion for adventure. The joy of life comes from our encounters with new experiences, and hence there is no greater joy than to have an endlessly changing horizon, for each day to have a new and different sun."
+			"author": "Christopher McCandless", 
+			"quote": "The very basic core of a man's living spirit is his passion for adventure. The joy of life comes from our encounters with new experiences, and hence there is no greater joy than to have an endlessly changing horizon, for each day to have a new and different sun."
 		},
 		{
-			"Author": "C.S. Lewis", 
-			"Quote": "There are far, far better things ahead than any we leave behind."
+			"author": "C.S. Lewis", 
+			"quote": "There are far, far better things ahead than any we leave behind."
 		},
 		{
-			"Author": "Jack Welch", 
-			"Quote": "Face reality as it is, not as it was or as you wish it to be."
+			"author": "Jack Welch", 
+			"quote": "Face reality as it is, not as it was or as you wish it to be."
 		},
 		{
-			"Author": "Nathan W. Morris", 
-			"Quote": "Edit your life frequently and ruthlessly. It's your masterpiece after all."
+			"author": "Nathan W. Morris", 
+			"quote": "Edit your life frequently and ruthlessly. It's your masterpiece after all."
 		},
 		{
-			"Author": "Stephen King", 
-			"Quote": "Talent is a wonderful thing, but it won't carry a quitter."
+			"author": "Stephen King", 
+			"quote": "Talent is a wonderful thing, but it won't carry a quitter."
 		},
 		{
-			"Author": "Morrie Camhi", 
-			"Quote": "We see things not as they are, we see them as WE are."
+			"author": "Morrie Camhi", 
+			"quote": "We see things not as they are, we see them as WE are."
 		},
 		{
-			"Author": "Ken Robinson", 
-			"Quote": "Curiosity is the engine of achievement."
+			"author": "Ken Robinson", 
+			"quote": "Curiosity is the engine of achievement."
 		},
 		{
-			"Author": "Tehmina Durrani", 
-			"Quote": "I found an inner strength to fight for myself. It was clear that nobody else would."
+			"author": "Tehmina Durrani", 
+			"quote": "I found an inner strength to fight for myself. It was clear that nobody else would."
 		},
 		{
-			"Author": "Johann Wolfgang von Goethe", 
-			"Quote": "The heights charm us, but the steps do not; with the mountain in our view we love to walk the plains."
+			"author": "Johann Wolfgang von Goethe", 
+			"quote": "The heights charm us, but the steps do not; with the mountain in our view we love to walk the plains."
 		},
 		{
-			"Author": "Mohammed Ali Bapir", 
-			"Quote": "Let your action manifest your thought, your belief and your passion."
+			"author": "Mohammed Ali Bapir", 
+			"quote": "Let your action manifest your thought, your belief and your passion."
 		},
 		{
-			"Author": "Bill Rodgers", 
-			"Quote": "I often lose motivation, but it's something I accept as normal."
+			"author": "Bill Rodgers", 
+			"quote": "I often lose motivation, but it's something I accept as normal."
 		},
 		{
-			"Author": "Wendy Tremayne", 
-			"Quote": "Start even if you don't know how."
+			"author": "Wendy Tremayne", 
+			"quote": "Start even if you don't know how."
 		},
 		{
-			"Author": "Babe Ruth", 
-			"Quote": "Never allow the fear of striking out keep you from playing the game!"
+			"author": "Babe Ruth", 
+			"quote": "Never allow the fear of striking out keep you from playing the game!"
 		},
 		{
-			"Author": "L.M. Fields", 
-			"Quote": "It doesn't matter where you've been, only where you are going."
+			"author": "L.M. Fields", 
+			"quote": "It doesn't matter where you've been, only where you are going."
 		},
 		{
-			"Author": "Richie Norton", 
-			"Quote": "To become who you want to become, make decisions that THAT person would make, TODAY."
+			"author": "Richie Norton", 
+			"quote": "To become who you want to become, make decisions that THAT person would make, TODAY."
 		},
 		{
-			"Author": "Dragos Bratasanu", 
-			"Quote": "Flow is a state of being when we are completely focused, and fully immersed in what we are doing. In flow our work seems effortless, creativity goes into overdrive, we feel inspired, and motivation springs forth from within."
+			"author": "Dragos Bratasanu", 
+			"quote": "Flow is a state of being when we are completely focused, and fully immersed in what we are doing. In flow our work seems effortless, creativity goes into overdrive, we feel inspired, and motivation springs forth from within."
 		},
 		{
-			"Author": "Greg Daugherty", 
-			"Quote": "Rejected pieces aren't failure; unwritten pieces are."
+			"author": "Greg Daugherty", 
+			"quote": "Rejected pieces aren't failure; unwritten pieces are."
 		},
 		{
-			"Author": "Dawn Garcia", 
-			"Quote": "We are not who we come from. We are who we allow ourselves to become."
+			"author": "Dawn Garcia", 
+			"quote": "We are not who we come from. We are who we allow ourselves to become."
 		},
 		{
-			"Author": "M.L. Shanahan", 
-			"Quote": "Fight everyday for a better life."
+			"author": "M.L. Shanahan", 
+			"quote": "Fight everyday for a better life."
 		},
 		{
-			"Author": "Qwana Reynolds-Frasier", 
-			"Quote": "Practice makes the hard things easy."
+			"author": "Qwana Reynolds-Frasier", 
+			"quote": "Practice makes the hard things easy."
 		}
 	]
 }

--- a/motivate/data/107.json
+++ b/motivate/data/107.json
@@ -87,6 +87,6 @@
         {
             "quote": "Quality is more important than quantity. One home run is much better than two doubles.",
             "author": "Steve Jobs"
-        },
+        }
     ]
 }

--- a/motivate/data/109.json
+++ b/motivate/data/109.json
@@ -10,8 +10,7 @@
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",
-                    "quote": "All Birds find shelter during a rain.
-                              But Eagle avoids rain by flying above the Clouds."
+                    "quote": "All Birds find shelter during a rain.\nBut Eagle avoids rain by flying above the Clouds."
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",
@@ -23,9 +22,7 @@
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",
-                    "quote": "If you fail, never give up because F.A.I.L. means “First Attempt In Learning”.
-                              End is not the end, if fact E.N.D. means “Effort Never Dies”. If you get No as an answer, remember N.O. means “Next Opportunity”.
-                              So Let’s be positive."
+                    "quote": "If you fail, never give up because F.A.I.L. means “First Attempt In Learning”.\nEnd is not the end, if fact E.N.D. means “Effort Never Dies”. If you get No as an answer, remember N.O. means “Next Opportunity”.\nSo Let’s be positive."
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",
@@ -73,8 +70,7 @@
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",
-                    "quote": "Dream, Dream Dream...
-                              Dreams transform into thoughts And thoughts result in action."
+                    "quote": "Dream, Dream Dream...\nDreams transform into thoughts And thoughts result in action."
                 },
                 {
                     "author": "Dr APJ Abdul Kalam",

--- a/motivate/data/119.json
+++ b/motivate/data/119.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "author": "Dumbledore–The Philosopher’s Stone  ",
-      "quote": "“There are all kinds of courage, it takes a great deal of bravery to stand up to our enemies, but just as much to 	stand up to our friends."
+      "quote": "There are all kinds of courage, it takes a great deal of bravery to stand up to our enemies, but just as much to stand up to our friends."
     },
     {
       "author": "Dumbledore–The Philosopher’s Stone ",
@@ -74,12 +74,12 @@
     },
     {
       "author": "Hagrid-The Goblet of Fire",
-      "quote": "I am what I am an’ I’m not ashamed. ‘Never be ashamed,’ my ol’ dad used ter say, ‘there’s some who’ll hold it against 		you, but they’re not worth bothern’ with."
+      "quote": "I am what I am an’ I’m not ashamed. ‘Never be ashamed,’ my ol’ dad used ter say, ‘there’s some who’ll hold it against you, but they’re not worth bothern’ with."
     },
     {
       "author": "Luna Lovegood–The Order of the Phoenix",
       "quote": "Things we lose have a way of coming back to us in the end, if not always in the way we expect."
-    },
+    }
     
   ]
 }

--- a/motivate/data/120.json
+++ b/motivate/data/120.json
@@ -79,7 +79,7 @@
     {
       "author": "Jack Ma",
       "quote": "No matter how tough the chase is, you should always have the dream you saw on the first day. It’ll keep you motivated and rescue you (from any weak thoughts)."
-    },
+    }
     
   ]
 }

--- a/motivate/data/121.json
+++ b/motivate/data/121.json
@@ -79,7 +79,7 @@
     {
       "author": "Soichiro Honda",
       "quote": "I enjoy working, and it isn’t because I’m president that I would deprive myself of that pleasure!"
-    },
+    }
     
   ]
 }

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -21,7 +21,7 @@ def getlink(file):
 
 
 def quote():
-    abspath = getlink(__file__) 
+    abspath = getlink(__file__)
     if abspath == '/usr/local':
         data_dir = os.path.join(abspath, 'share', 'motivate', 'data')
     else:
@@ -35,7 +35,24 @@ def quote():
     rand_no = random.randint(1, num_of_json)
     filename = os.path.join(data_dir, str(rand_no).zfill(3) + '.json')
     with open(filename) as json_data:
-        quotes = json.load(json_data)
+        try:
+            quotes = json.load(json_data)
+        except ValueError:
+            print ("---------------Debug info begins:--------------")
+            print("Oops, we met a ValueError.")
+            print("Please check this file "+filename)
+            print("1. A Possible reason is that there is a redundant comma behind last group of author/quote in this json file.")
+            print("   If so, delete that redundant comma, then it will run smoothly.")
+            print("2. Another possible reason is that there is hard line-break or tab in that file.")
+            print("   However JSON don't support that. Please use '\\n' or '\\t'.")
+            print("For later actions, I help you wrote this filename to JSON_ERROR_LIST.txt.")
+            print("I suggest you to test those json file in this website: jsonlint.com")
+            f_tmp = open('JSON_ERROR_LIST.txt', "a")
+            f_tmp.write(filename+"\n")
+            f_tmp.close()
+            print ("---------------Debug info ends:--------------")
+            return
+
         ran_no = random.randint(1, len(quotes["data"])) - 1
         if "quote" in quotes["data"][ran_no]:
             quote = quotes["data"][ran_no]["quote"]


### PR DESCRIPTION
The python script will display helpful debug information when loading problematic JSON file with following two kinds of problems:
1. A JSON decoder error might be caused by a redundant comma after last group of quote, for example, the last several lines in 120.json:
```
{
      "author": "Jack Ma",
      "quote": "No matter how tough the chase is, you should always have the dream you saw on the first day. It’ll keep you motivated and rescue you (from any weak thoughts)."
    },

  ]
}
```
Delete the comma, it runs smoothly. This problem occurs in these json files: 119, 120, 121.
```
{
      "author": "Jack Ma",
      "quote": "No matter how tough the chase is, you should always have the dream you saw on the first day. It’ll keep you motivated and rescue you (from any weak thoughts)."
    }

  ]
}
```
2. Another Reason is: 

> JSON does not allow "real" newlines in its data; it can only have escaped newlines.

So they should use \n instead of real line-breaks in 109.json and use \t instead of tabs in 119.json.

I added debug info for these ValueErrors. And suggest contributors to validate their new JSON file at this website https://jsonlint.com/ before commit.
  
  
  