### PR TITLE
moved install and data directory to /opt/motivate

### DIFF
--- a/motivate/data/data
+++ b/motivate/data/data
@@ -1,1 +1,0 @@
-/home/ankit/Web-D/motivate/motivate/data/

--- a/motivate/install.sh
+++ b/motivate/install.sh
@@ -5,13 +5,15 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-INSTALLDIR="/usr/local/share"
+INSTALLDIR="/opt/motivate"
 
 # Create motivate folder
-mkdir -p $INSTALLDIR/motivate
+mkdir -p $INSTALLDIR
 
-# Symlink the json datafolder
-ln -sf $PWD/data/ $INSTALLDIR/motivate/data
+# Copy the datafolder and set permissions
+cp -r $PWD/data $INSTALLDIR/
+chmod -R 777 $INSTALLDIR/data
 
-# Copy the executable
-cp motivate.py /usr/local/bin/motivate
+# Copy and link the executable
+cp motivate.py $INSTALLDIR
+ln -s $INSTALLDIR/motivate.py /usr/local/bin/motivate

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -17,16 +17,19 @@ def getlink(file):
 
 def quote():
     abspath = getlink(__file__)
-    if abspath == '/usr/local':
-        data_dir = os.path.join(abspath, 'share', 'motivate', 'data')
-    else:
+
+    if os.name == 'nt':
         data_dir = os.path.join(abspath, 'motivate', 'data')
+    else:
+        data_dir = os.path.join('/opt', 'motivate', 'data')
+
     try:
         num_of_json = len([f for f in os.listdir(data_dir)
                            if os.path.isfile(os.path.join(data_dir, f))])
     except FileNotFoundError:
         print("Can't find the data folder. You probably haven't run 'install.sh' yet.")
         exit(1)
+
     rand_no = random.randint(1, num_of_json)
     filename = os.path.join(data_dir, str(rand_no).zfill(3) + '.json')
     with open(filename) as json_data:

--- a/motivate/motivate.py
+++ b/motivate/motivate.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import platform
 import random
 
 
@@ -55,7 +54,7 @@ def quote():
         if "quote" in quotes["data"][ran_no]:
             quote = quotes["data"][ran_no]["quote"]
             author = quotes["data"][ran_no]["author"]
-            if platform.system() == "Windows":
+            if os.name == "nt":
                 quote = "\"" + quote + "\""
                 author = "--" + author
                 white_code = ""


### PR DESCRIPTION
- Moved the default installation directory to /opt/motivate 
- data directory now resides inside the /opt/motivate
- Executable "motivate.py" is linked to /usr/local/bin/motivate from /opt/motivate/motivate.py
- data directory no longer requires to be linked
- data directory is setup with permission 777 to allow normal users to update JSON files
- User can delete cloned repo if he/she so desires